### PR TITLE
Remove the epel-testing repo for rssh

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -67,8 +67,6 @@
       package:
         name: rssh
         state: installed
-        # TODO: remove when it enters stable EPEL
-        enablerepo: epel-testing
     - name: Add RSSH config for doc builder's user
       lineinfile:
         path: /etc/rssh.conf


### PR DESCRIPTION
rssh is now in stable repo, no need to pull it from testing.